### PR TITLE
Update to Make Use of New Minigames Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ All the minigames here are based on those from the [Randomat 2.0](https://steamc
 * ConVars:
   * ttt2_minigames_freeze_timer - Time between freezes
   * ttt2_minigames_freeze_duration - Duration of freeze
+  * ttt2_minigames_freeze_quotes  - Replace minigame name with ice-related pop culture quotes for pop up
+  * ttt2_minigames_freeze_desc  - Show the minigame explanation
+
 
 ### Bad Gas!
 * Name: sh_gas_minigame

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_minigames_gameboy.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_minigames_gameboy.lua
@@ -40,45 +40,45 @@ SWEP.Primary.Ammo = "none"
 SWEP.Primary.ClipsSize = 1
 SWEP.Primary.DefaultClip = 1
 
-function SWEP:SelectGame()
-  if SERVER then
-    local mgs = minigames.GetList()
-
-    if #mgs == 0 then return end
-
-    local availableMinigames = {}
-    local forcedNextMinigame = minigames.GetForcedNextMinigame()
-
-    for i = 1, #mgs do
-      local minigame = mgs[i]
-
-      if not GetConVar("ttt2_minigames_" .. minigame.name .. "_enabled"):GetBool() or not minigame:IsSelectable() then continue end
-
-      if forcedNextMinigame and forcedNextMinigame.name == minigame.name then
-        forcedNextMinigame = nil
-        return minigame
-      end
-
-      local b = true
-
-      local r = GetConVar("ttt2_minigames_" .. minigame.name .. "_random"):GetInt()
-
-      if r > 0 and r < 100 then
-        b = math.random(100) <= r
-      elseif r <= 0 then
-        b = false
-      end
-
-      if b then
-        availableMinigames[#availableMinigames + 1] = minigame
-      end
-    end
-
-    if #availableMinigames == 0 then return end
-
-    return availableMinigames[math.random(#availableMinigames)]
-  end
-end
+-- function SWEP:SelectGame()
+--   if SERVER then
+--     local mgs = minigames.GetList()
+--
+--     if #mgs == 0 then return end
+--
+--     local availableMinigames = {}
+--     local forcedNextMinigame = minigames.GetForcedNextMinigame()
+--
+--     for i = 1, #mgs do
+--       local minigame = mgs[i]
+--
+--       if not GetConVar("ttt2_minigames_" .. minigame.name .. "_enabled"):GetBool() or not minigame:IsSelectable() then continue end
+--
+--       if forcedNextMinigame and forcedNextMinigame.name == minigame.name then
+--         forcedNextMinigame = nil
+--         return minigame
+--       end
+--
+--       local b = true
+--
+--       local r = GetConVar("ttt2_minigames_" .. minigame.name .. "_random"):GetInt()
+--
+--       if r > 0 and r < 100 then
+--         b = math.random(100) <= r
+--       elseif r <= 0 then
+--         b = false
+--       end
+--
+--       if b then
+--         availableMinigames[#availableMinigames + 1] = minigame
+--       end
+--     end
+--
+--     if #availableMinigames == 0 then return end
+--
+--     return availableMinigames[math.random(#availableMinigames)]
+--   end
+-- end
 
 function SWEP:Initialize()
   util.PrecacheSound("weapons/c4_initiate.wav")
@@ -87,14 +87,14 @@ end
 function SWEP:PrimaryAttack()
   if SERVER then
     print("1")
-    minigame = self:SelectGame()
+    minigame = minigames.Select()
     if not minigame then self:Remove() return end
     print("Minigame Found")
 
     ActivateMinigame(minigame)
     print("Minigame Activated")
 
-    DamageLog("[TTT2][MINIGAME] : " .. self:GetOwner():Nick() .. " [" .. self.Owner:GetRoleString() .. "] used their Gameboy")
+    DamageLog("[TTT2][MINIGAME] : " .. self:GetOwner():Nick() .. " [" .. self:GetOwner():GetRoleString() .. "] used their Randomat X")
     self:SetNextPrimaryFire(CurTime() + 10)
 
     self:Remove()

--- a/lua/minigames/minigames/sh_barrels_minigame.lua
+++ b/lua/minigames/minigames/sh_barrels_minigame.lua
@@ -10,19 +10,19 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 10,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_barrels_count (Def. 3)"
   },
   ttt2_minigames_barrels_range = {
     slider = true,
     min = 100,
     max = 1000,
-    desc = "(Def. 100)"
+    desc = "ttt2_minigames_barrels_range (Def. 100)"
   },
   ttt2_minigames_barrels_timer = {
     slider = true,
     min = 1,
     max = 240,
-    desc = "(Def. 60)"
+    desc = "ttt2_minigames_barrels_timer (Def. 60)"
   }
 }
 

--- a/lua/minigames/minigames/sh_bees_minigame.lua
+++ b/lua/minigames/minigames/sh_bees_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 10,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_bees_count (Def. 4)"
   }
 }
 

--- a/lua/minigames/minigames/sh_blind_minigame.lua
+++ b/lua/minigames/minigames/sh_blind_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 30)"
+    desc = "ttt2_minigames_blind_duration (Def. 30)"
   }
 }
 

--- a/lua/minigames/minigames/sh_blink_minigame.lua
+++ b/lua/minigames/minigames/sh_blink_minigame.lua
@@ -10,14 +10,14 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 20,
-    desc = "(Def. 12)"
+    desc = "ttt2_minigames_blink_cap (Def. 12)"
   },
   ttt2_minigames_blink_delay = {
     slider = true,
     min = 0,
     max = 3,
     decimal = 1,
-    desc = "(Def. 0.5)"
+    desc = "ttt2_minigames_blink_delay (Def. 0.5)"
   }
 }
 

--- a/lua/minigames/minigames/sh_butter_minigame.lua
+++ b/lua/minigames/minigames/sh_butter_minigame.lua
@@ -10,11 +10,11 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 30,
-    desc = "(Def. 10)"
+    desc = "ttt2_minigames_butter_timer (Def. 10)"
   },
   ttt2_minigames_butter_affectall = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_butter_affectall (Def. 0)"
   }
 }
 

--- a/lua/minigames/minigames/sh_cantstop_minigame.lua
+++ b/lua/minigames/minigames/sh_cantstop_minigame.lua
@@ -8,7 +8,7 @@ MINIGAME.contact = "Zzzaaaccc13 on TTT2 Discord"
 MINIGAME.conVarData = {
   ttt2_minigames_cantstop_disable_back = {
     checkbox = true,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_cantstop_disable_back (Def. 1)"
   }
 }
 

--- a/lua/minigames/minigames/sh_communism_minigame.lua
+++ b/lua/minigames/minigames/sh_communism_minigame.lua
@@ -35,7 +35,7 @@ if SERVER then
       net.Start("ttt2_communism_orderpopup")
       net.WriteString(ply:GetRoleString())
       net.WriteString(equipment)
-      net.WriteTable(ply:GetRoleColor())
+      net.WriteColor(ply:GetRoleColor())
       net.Broadcast()
     end)
   end
@@ -47,9 +47,9 @@ elseif CLIENT then
   net.Receive("ttt2_communism_orderpopup", function()
     local rolestring = net.ReadString()
     local equipment = net.ReadString()
-    local rolecolor = net.ReadTable()
+    local rolecolor = net.ReadColor()
     EPOP:AddMessage({
-      text = rolestring .. " bought everyone " .. equipment,
+      text = LANG.GetParamTranslation("ttt2mg_communism_epop", {role = rolestring, item = equipment}),
       color = rolecolor},
       "",
       2

--- a/lua/minigames/minigames/sh_crabs_minigame.lua
+++ b/lua/minigames/minigames/sh_crabs_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 10,
-    desc = "(Def. 5)"
+    desc = "ttt2_minigames_crabs_count (Def. 5)"
   }
 }
 

--- a/lua/minigames/minigames/sh_credits_minigame.lua
+++ b/lua/minigames/minigames/sh_credits_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 10,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_credits_count (Def. 1)"
   }
 }
 

--- a/lua/minigames/minigames/sh_crowbar_minigame.lua
+++ b/lua/minigames/minigames/sh_crowbar_minigame.lua
@@ -11,13 +11,13 @@ MINIGAME.conVarData = {
     min = 1,
     max = 10,
     decimal = 1,
-    desc = "(Def. 2.5)"
+    desc = "ttt2_minigames_crowbar_dmg (Def. 2.5)"
   },
   ttt2_minigames_crowbar_push = {
     slider = true,
     min = 1,
     max = 100,
-    desc = "(Def. 20)"
+    desc = "ttt2_minigames_crowbar_push (Def. 20)"
   }
 }
 

--- a/lua/minigames/minigames/sh_dying_minigame.lua
+++ b/lua/minigames/minigames/sh_dying_minigame.lua
@@ -10,24 +10,24 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 3)"
+    desc = "ttt2_minigames_dying_timer (Def. 3)"
   },
 
   ttt2_minigames_dying_dmg = {
     slider = true,
     min = 1,
     max = 100,
-    desc = "(Def. 5)"
+    desc = "ttt2_minigames_dying_dmg (Def. 5)"
   },
 
   ttt2_minigames_dying_affectall = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_dying_affectall (Def. 0)"
   },
 
   ttt2_minigames_dying_cankill = {
     checkbox = true,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_dying_cankill (Def. 1)"
   }
 }
 

--- a/lua/minigames/minigames/sh_explode_minigame.lua
+++ b/lua/minigames/minigames/sh_explode_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 120,
-    desc = "(Def. 30)"
+    desc = "ttt2_minigames_explode_timer (Def. 30)"
   }
 }
 

--- a/lua/minigames/minigames/sh_explode_minigame.lua
+++ b/lua/minigames/minigames/sh_explode_minigame.lua
@@ -71,11 +71,12 @@ if SERVER then
 end
 
 if CLIENT then
+  function MINIMGAME:ShowActivationEPOP() end
   net.Receive("explosion_minigame_exploded", function()
     local name = net.ReadString()
 
     EPOP:AddMessage({
-      text = name .. " exploded!",
+      text = LANG.GetParamTranslation("ttt2mg_explode_epop", {nick = name}),
       color = COLOR_ORANGE,
       6
     })

--- a/lua/minigames/minigames/sh_flash_minigame.lua
+++ b/lua/minigames/minigames/sh_flash_minigame.lua
@@ -10,11 +10,10 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 100,
-    desc = "(Def. 50)"
+    desc = "ttt2_minigames_flash_scale (Def. 50)"
   }
 }
 
-ttt2_minigames_flash_scale = CreateConVar("ttt2_minigames_flash_scale", "50", {FCVAR_ARCHIVE}, "Multiplier for time scale")
 
 if CLIENT then
   MINIGAME.lang = {
@@ -22,13 +21,22 @@ if CLIENT then
       English = "Speeeeeed!"
     },
     desc = {
-      English = "Everthing is fast as Flash now! (" .. ttt2_minigames_flash_scale:GetInt() .. "% faster)"
+      English = "Everthing is fast as Flash now! ({scale}% faster)"
     }
   }
 end
 
 if SERVER then
+  util.AddNetworkString("ttt2mg_flash_epop")
+  local ttt2_minigames_flash_scale = CreateConVar("ttt2_minigames_flash_scale", "50", {FCVAR_ARCHIVE}, "Multiplier for time scale")
+  function MINIGAME:ShowActivationEPOP()
+    net.Start("ttt2mg_flash_epop")
+    net.WriteInt(ttt2_minigames_flash_scale:GetInt(), 32)
+    net.WriteString(self.name)
+    net.Broadcast()
+  end
   function MINIGAME:OnActivation()
+    self:ShowActivationEPOP()
     ts = game.GetTimeScale()
     game.SetTimeScale(ts + (ttt2_minigames_flash_scale:GetInt() / 100))
   end
@@ -36,4 +44,21 @@ if SERVER then
   function MINIGAME:OnDeactivation()
     game.SetTimeScale(1)
   end
+
+
+else
+  function MINIGAME:ShowActivationEPOP() end
+  net.Receive("ttt2mg_flash_epop", function()
+    local mgscale = net.ReadInt(32)
+    local name = net.ReadString()
+    EPOP:AddMessage({
+        text  = LANG.TryTranslation("ttt2_minigames_" .. name .. "_name"),
+        color = COLOR_ORANGE
+    },
+      LANG.GetParamTranslation("ttt2_minigames_" .. name .. "_desc", {scale = mgscale}),
+      12,
+      nil,
+      true
+    )
+  end)
 end

--- a/lua/minigames/minigames/sh_fov_minigame.lua
+++ b/lua/minigames/minigames/sh_fov_minigame.lua
@@ -11,7 +11,7 @@ MINIGAME.conVarData = {
     min = 0,
     max = 3,
     decimal = 1,
-    desc = "(Def. 1.5)"
+    desc = "ttt2_minigames_fov_scale (Def. 1.5)"
   }
 }
 

--- a/lua/minigames/minigames/sh_freeze_minigame.lua
+++ b/lua/minigames/minigames/sh_freeze_minigame.lua
@@ -10,24 +10,24 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 10,
-    desc = "(Def. 5)"
+    desc = "ttt2_minigames_freeze_duration (Def. 5)"
   },
 
   ttt2_minigames_freeze_timer = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 30)"
+    desc = "ttt2_minigames_freeze_timer (Def. 30)"
   },
 
   ttt2_minigames_freeze_quotes = {
     checkbox = true,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_freeze_quotes (Def. 1)"
   },
 
   ttt2_minigames_freeze_desc = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_freeze_desc (Def. 0)"
   }
 }
 

--- a/lua/minigames/minigames/sh_gas_minigame.lua
+++ b/lua/minigames/minigames/sh_gas_minigame.lua
@@ -10,27 +10,27 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 10,
-    desc = "(Def. 15)"
+    desc = "ttt2_minigames_gas_timer (Def. 15)"
   },
 
   ttt2_minigames_gas_affectall = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_gas_affectall (Def. 0)"
   },
 
   ttt2_minigames_gas_discomb = {
     checkbox = true,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_gas_discomb (Def. 1)"
   },
 
   ttt2_minigames_gas_fire = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_gas_fire (Def. 0)"
   },
 
   ttt2_minigames_gas_smoke = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_gas_smoke (Def. 0)"
   }
 }
 

--- a/lua/minigames/minigames/sh_grave_minigame.lua
+++ b/lua/minigames/minigames/sh_grave_minigame.lua
@@ -10,14 +10,14 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 100,
-    desc = "(Def. 30)"
+    desc = "ttt2_minigames_grave_health (Def. 30)"
   },
 
   ttt2_minigames_grave_delay = {
     slider = true,
     min = 0,
     max = 60,
-    desc = "(Def. 3)"
+    desc = "ttt2_minigames_grave_delay (Def. 3)"
   }
 }
 

--- a/lua/minigames/minigames/sh_grave_minigame.lua
+++ b/lua/minigames/minigames/sh_grave_minigame.lua
@@ -38,6 +38,7 @@ if SERVER then
   function MINIGAME:OnActivation()
     hook.Add("PostPlayerDeath", "GraveMinigame", function(ply)
       if ply.RisenForRound == true then return end
+      -- local revivalreason = LANG.TryTranslation("ttt2_minigames_" .. self.name .. "_name")
 
       ply:Revive(
         ttt2_minigames_grave_delay:GetInt(),
@@ -52,7 +53,7 @@ if SERVER then
         true,
         false
       )
-      ply:SendRevivalReason("RISE FROM YOUR GRAVE!")
+      ply:SendRevivalReason("ttt2_minigames_" .. self.name .. "_name")
     end)
   end
 

--- a/lua/minigames/minigames/sh_gungame_minigame.lua
+++ b/lua/minigames/minigames/sh_gungame_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 5)"
+    desc = "ttt2_minigames_gungame_timer (Def. 5)"
   }
 }
 

--- a/lua/minigames/minigames/sh_harpoon_minigame.lua
+++ b/lua/minigames/minigames/sh_harpoon_minigame.lua
@@ -10,12 +10,12 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 30,
-    desc = "(Def. 3)"
+    desc = "ttt2_minigames_harpoon_timer (Def. 3)"
   },
 
   ttt2_minigames_harpoon_strip = {
     checkbox = true,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_harpoon_strip (Def. 1)"
   },
 }
 

--- a/lua/minigames/minigames/sh_intensifies_minigame.lua
+++ b/lua/minigames/minigames/sh_intensifies_minigame.lua
@@ -28,47 +28,10 @@ end
 
 if SERVER then
   local ttt2_minigames_intensifies_timer = CreateConVar("ttt2_minigames_intensifies_timer", "20", {FCVAR_ARCHIVE}, "How often should a new game be activated")
-  function MINIGAME:SelectGame()
-    local mgs = minigames.GetList()
-
-    if #mgs == 0 then return end
-
-    local availableMinigames = {}
-    local forcedNextMinigame = minigames.GetForcedNextMinigame()
-
-    for i = 1, #mgs do
-      local minigame = mgs[i]
-
-      if not GetConVar("ttt2_minigames_" .. minigame.name .. "_enabled"):GetBool() or not minigame:IsSelectable() then continue end
-
-      if forcedNextMinigame and forcedNextMinigame.name == minigame.name then
-        forcedNextMinigame = nil
-        return minigame
-      end
-
-      local b = true
-
-      local r = GetConVar("ttt2_minigames_" .. minigame.name .. "_random"):GetInt()
-
-      if r > 0 and r < 100 then
-        b = math.random(100) <= r
-      elseif r <= 0 then
-        b = false
-      end
-
-      if b then
-        availableMinigames[#availableMinigames + 1] = minigame
-      end
-    end
-
-    if #availableMinigames == 0 then return end
-
-    return availableMinigames[math.random(#availableMinigames)]
-  end
 
   function MINIGAME:OnActivation()
     timer.Create("IntensifiesMinigame", ttt2_minigames_intensifies_timer:GetInt(), 0, function()
-      local minigame = self:SelectGame()
+      local minigame = minigames.Select()
       if not minigame then return end
 
       ActivateMinigame(minigame)

--- a/lua/minigames/minigames/sh_intensifies_minigame.lua
+++ b/lua/minigames/minigames/sh_intensifies_minigame.lua
@@ -11,7 +11,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 20)"
+    desc = "ttt2_minigames_intensifies_timer (Def. 20)"
   }
 }
 

--- a/lua/minigames/minigames/sh_inventory_minigame.lua
+++ b/lua/minigames/minigames/sh_inventory_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 15)"
+    desc = "ttt2_minigames_inventory_timer (Def. 15)"
   }
 }
 

--- a/lua/minigames/minigames/sh_jesters_minigame.lua
+++ b/lua/minigames/minigames/sh_jesters_minigame.lua
@@ -8,12 +8,12 @@ MINIGAME.contact = "Zzzaaaccc13 on TTT2 Discord"
 MINIGAME.conVarData = {
   ttt2_minigames_jesters_base_traitor = {
     checkbox = true,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_jesters_base_traitor (Def. 1)"
   },
 
   ttt2_minigames_jesters_base_detective = {
     checkbox = true,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_jesters_base_detective (Def. 1)"
   }
 }
 

--- a/lua/minigames/minigames/sh_jump_minigame.lua
+++ b/lua/minigames/minigames/sh_jump_minigame.lua
@@ -45,10 +45,12 @@ if CLIENT then
     local name = net.ReadString()
 
     EPOP:AddMessage({
-      text = name .. " tried to jump twice..",
+      text = LANG.GetParamTranslation("ttt2mg_jump_epop", {nick = name}),
       color = COLOR_ORANGE},
-      "",
-      3
+      nil,
+      5,
+      nil,
+      false
     )
   end)
 end

--- a/lua/minigames/minigames/sh_lifesteal_minigame.lua
+++ b/lua/minigames/minigames/sh_lifesteal_minigame.lua
@@ -10,14 +10,14 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 100,
-    desc = "(Def. 25)"
+    desc = "ttt2_minigames_lifesteal_health (Def. 25)"
   },
 
   ttt2_minigames_lifesteal_cap = {
     slider = true,
     min = 0,
     max = 300,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_lifesteal_cap (Def. 0)"
   }
 }
 

--- a/lua/minigames/minigames/sh_malfunction_minigame.lua
+++ b/lua/minigames/minigames/sh_malfunction_minigame.lua
@@ -10,19 +10,19 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 15)"
+    desc = "ttt2_minigames_malfunction_up (Def. 15)"
   },
 
   ttt2_minigames_malfunction_lw = {
     slider = true,
     min = 0,
     max = 60,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_malfunction_lw (Def. 1)"
   },
 
   ttt2_minigames_malfunction_all = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_malfunction_all (Def. 0)"
   },
 
   ttt2_minigames_malfunction_dur = {
@@ -30,7 +30,7 @@ MINIGAME.conVarData = {
     min = 0,
     max = 3,
     decimal = 1,
-    desc = "(Def. 0.5)"
+    desc = "ttt2_minigames_malfunction_dur (Def. 0.5)"
   }
 }
 

--- a/lua/minigames/minigames/sh_moongravity_minigame.lua
+++ b/lua/minigames/minigames/sh_moongravity_minigame.lua
@@ -11,7 +11,7 @@ MINIGAME.conVarData = {
     min = 0,
     max = 1,
     decimal = 1,
-    desc = "(Def. 0.1)"
+    desc = "ttt2_minigames_moongravity_gravity (Def. 0.1)"
   }
 }
 

--- a/lua/minigames/minigames/sh_murder_minigame.lua
+++ b/lua/minigames/minigames/sh_murder_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 1000,
-    desc = "(Def. 100)"
+    desc = "ttt2_minigames_murder_knife_dmg (Def. 100)"
   },
 
   ttt2_minigames_murder_knife_speed = {
@@ -18,7 +18,7 @@ MINIGAME.conVarData = {
     min = 1,
     max = 2,
     decimal = 1,
-    desc = "(Def. 1.2)"
+    desc = "ttt2_minigames_murder_knife_speed (Def. 1.2)"
   }
 }
 

--- a/lua/minigames/minigames/sh_president_minigame.lua
+++ b/lua/minigames/minigames/sh_president_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 200,
-    desc = "(Def. 100)"
+    desc = "ttt2_minigames_president_bonushp (Def. 100)"
   }
 }
 

--- a/lua/minigames/minigames/sh_privacy_minigame.lua
+++ b/lua/minigames/minigames/sh_privacy_minigame.lua
@@ -22,31 +22,34 @@ if SERVER then
   function MINIGAME:OnActivation()
     hook.Add("TTTOrderedEquipment", "PrivacyMinigameNotification", function(ply, equipment, is_item)
         local rolename = ply:GetRoleString()
+        local rolecolor = ply:GetRoleLtColor() or COLOR_ORANGE
+
 
         net.Start("privacy_mg_notif")
         net.WriteString(rolename)
-        net.WriteEntity(ply)
-        net.WriteTable(ply:GetRoleColor())
+        net.WriteColor(rolecolor)
         net.WriteString(equipment)
-        net.WriteBool(is_item)
         net.Broadcast()
     end)
   end
 
   function MINIGAME:OnDeactivation()
-
+    hook.Remove("TTTOrderedEquipment", "PrivacyMinigameNotification")
   end
 elseif CLIENT then
   net.Receive("privacy_mg_notif", function()
     local rolename = net.ReadString()
-    local rolecolor = net.ReadTable()
+    local rolecolor = net.ReadColor()
     local equipment = net.ReadString()
+    equipment = LANG.TryTranslation(equipment) or equipment
 
     EPOP:AddMessage({
-      text = rolename .. " bought " .. equipment,
+      text = LANG.GetParamTranslation("ttt2mg_privacy_epop", {role = rolename, item = equipment}),
       color = rolecolor},
-      "",
-      2
+      nil,
+      4,
+      nil,
+      true
     )
   end)
 end

--- a/lua/minigames/minigames/sh_randomhealth_minigame.lua
+++ b/lua/minigames/minigames/sh_randomhealth_minigame.lua
@@ -10,14 +10,14 @@ MINIGAME.conVarData = {
     slider = true,
     min = -100,
     max = 100,
-    desc = "(Def. 100)"
+    desc = "ttt2_minigames_randomhealth_up (Def. 100)"
   },
 
   ttt2_minigames_randomhealth_lw = {
     slider = true,
     min = -100,
     max = 100,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_randomhealth_lw (Def. 0)"
   }
 }
 

--- a/lua/minigames/minigames/sh_randomxn_minigame.lua
+++ b/lua/minigames/minigames/sh_randomxn_minigame.lua
@@ -11,7 +11,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 20,
-    desc = "(Def. 5)"
+    desc = "ttt2_minigames_randomxn_count (Def. 5)"
   }
 }
 

--- a/lua/minigames/minigames/sh_randomxn_minigame.lua
+++ b/lua/minigames/minigames/sh_randomxn_minigame.lua
@@ -15,61 +15,25 @@ MINIGAME.conVarData = {
   }
 }
 
-local ttt2_minigames_randomxn_count = CreateConVar("ttt2_minigames_randomxn_count", "5", {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "Number of games to activate")
-
 if CLIENT then
   MINIGAME.lang = {
     name = {
       English = "Multigame"
-    },
-    desc = {
-      English = "Random x" .. ttt2_minigames_randomxn_count:GetInt()
     }
   }
 end
 
 if SERVER then
-  function MINIGAME:SelectGame()
-    local mgs = minigames.GetList()
-
-    if #mgs == 0 then return end
-
-    local availableMinigames = {}
-    local forcedNextMinigame = minigames.GetForcedNextMinigame()
-
-    for i = 1, #mgs do
-      local minigame = mgs[i]
-
-      if not GetConVar("ttt2_minigames_" .. minigame.name .. "_enabled"):GetBool() or not minigame:IsSelectable() then continue end
-
-      if forcedNextMinigame and forcedNextMinigame.name == minigame.name then
-        forcedNextMinigame = nil
-        return minigame
-      end
-
-      local b = true
-
-      local r = GetConVar("ttt2_minigames_" .. minigame.name .. "_random"):GetInt()
-
-      if r > 0 and r < 100 then
-        b = math.random(100) <= r
-      elseif r <= 0 then
-        b = false
-      end
-
-      if b then
-        availableMinigames[#availableMinigames + 1] = minigame
-      end
-    end
-
-    if #availableMinigames == 0 then return end
-
-    return availableMinigames[math.random(#availableMinigames)]
+  local ttt2_minigames_randomxn_count = CreateConVar("ttt2_minigames_randomxn_count", "5", {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "Number of games to activate")
+  function MINIGAME:ShowActivationEPOP()
+    net.Start("ttt2mg_randomxn_epop")
+    net.WriteInt(ttt2_minigames_randomxn_count:GetInt(), 32)
+    net.Broadcast()
   end
 
   function MINIGAME:OnActivation()
     timer.Create("RandomxnMinigame", 12.5, ttt2_minigames_randomxn_count:GetInt(), function()
-      local minigame = self:SelectGame()
+      local minigame = minigames.Select()
       if not minigame then return end
 
       ActivateMinigame(minigame)
@@ -79,5 +43,19 @@ if SERVER then
   function MINIGAME:OnDeactivation()
     timer.Remove("RandomxnMinigame")
   end
+else
+  function MINIGAME:ShowActivationEPOP() end
 
+  net.Receive("ttt2mg_randomxn_epop", function()
+    local mgcount = net.ReadInt(32)
+    EPOP:AddMessage({
+        text = LANG.GetParamTranslation("ttt2mg_randomxn_epop", {count = mgcount}),
+        color = COLOR_ORANGE
+    },
+      nil,
+      12,
+      nil,
+      true
+    )
+  end)
 end

--- a/lua/minigames/minigames/sh_regen_minigame.lua
+++ b/lua/minigames/minigames/sh_regen_minigame.lua
@@ -10,14 +10,14 @@ MINIGAME.conVarData = {
     slider = true,
     min = 0,
     max = 60,
-    desc = "(Def. 10)"
+    desc = "ttt2_minigames_regen_delay (Def. 10)"
   },
 
   ttt2_minigames_regen_hp = {
     slider = true,
     min = 1,
     max = 25,
-    desc = "(Def. 1)"
+    desc = "ttt2_minigames_regen_hp (Def. 1)"
   }
 }
 

--- a/lua/minigames/minigames/sh_shrink_minigame.lua
+++ b/lua/minigames/minigames/sh_shrink_minigame.lua
@@ -11,7 +11,7 @@ MINIGAME.conVarData = {
     min = 0,
     max = 1,
     decimal = 1,
-    desc = "(Def. 0.5)"
+    desc = "ttt2_minigames_shrink_scale (Def. 0.5)"
   }
 }
 

--- a/lua/minigames/minigames/sh_soulmate_minigame.lua
+++ b/lua/minigames/minigames/sh_soulmate_minigame.lua
@@ -8,7 +8,7 @@ MINIGAME.contact = "Zzzaaaccc13 on TTT2 Discord"
 MINIGAME.conVarData = {
   ttt2_minigames_soulmate_all = {
     checkbox = true,
-    desc = "(Def. 0)"
+    desc = "ttt2_minigames_soulmate_all (Def. 0)"
   }
 }
 
@@ -24,6 +24,7 @@ if CLIENT then
 end
 
 if SERVER then
+  util.AddNetworkString("ttt2mg_soulmate_epop")
   local ttt2_minigames_soulmate_all = CreateConVar("ttt2_minigames_soulmate_all", "0", {FCVAR_ARCHIVE}, "Whether everyone should have a soulmate")
   function MINIGAME:OnActivation()
     local x = 0
@@ -52,36 +53,81 @@ if SERVER then
       size = #ply2
 
       for i = 1, #ply2 do
-        ply1[i]:PrintMessage(HUD_PRINTTALK, "Your soulmate is " .. ply2[i]:Nick())
-        ply1[i]:PrintMessage(HUD_PRINTCENTER, "Your soulmate is " .. ply2[i]:Nick())
-        ply2[i]:PrintMessage(HUD_PRINTTALK, "Your soulmate is " .. ply1[i]:Nick())
-        ply2[i]:PrintMessage(HUD_PRINTCENTER, "Your soulmate is " .. ply1[i]:Nick())
+        local ply_1 = ply1[i]
+        local ply_2 = ply2[i]
+        net.Start("ttt2mg_soulmate_epop")
+        net.WriteString("ttt2mg_soulmate_yours")
+        net.WriteString(ply_2:Nick())
+        net.Send(ply_1)
+        net.Start("ttt2mg_soulmate_epop")
+        net.WriteString("ttt2mg_soulmate_yours")
+        net.WriteString(ply_1:Nick())
+        net.Send(ply_2)
       end
       if ply1[#ply2 + 1] then
-        ply1[#ply2 + 1]:PrintMessage(HUD_PRINTTALK, "You have no soulmate :(")
-        ply1[#ply2 + 1]:PrintMessage(HUD_PRINTCENTER, "You have no soulmate :(")
+        local ply_1 = ply1[#ply2 + 1]
+        net.Start("ttt2mg_soulmate_epop")
+        net.WriteString("ttt2mg_soulmate_none")
+        net.Send(ply_1)
       end
 
+      timer.Create("SoulmatesMinigameTimer", 0.1, 0, function()
+        for i = 1, size do
+          if not ply1[i]:Alive() and ply2[i]:Alive() then
+            ply2[i]:Kill()
+          elseif ply1[i]:Alive() and not ply2[i]:Alive() then
+            ply1[i]:Kill()
+          end
+        end
+      end)
     else
-      for i = 1, #plys do
-        local ply = plys[i]
-        ply:PrintMessage(HUD_PRINTTALK, ply1[1]:Nick() .. " and " .. ply2[2]:Nick() .. " are now soulmates.")
-        ply:PrintMessage(HUD_PRINTCENTER, ply1[1]:Nick() .. " and " .. ply2[2]:Nick() .. " are now soulmates.")
-      end
+      local rnd1 = math.random(#ply1)
+      local rnd2 = math.random(#ply2)
+      local ply_1 = ply1[rnd1]
+      local ply_2 = ply2[rnd2]
+      plys = player.GetAll()
+      net.Start("ttt2mg_soulmate_epop")
+      net.WriteString("ttt2mg_soulmate_pair")
+      net.WriteString(ply_1:Nick())
+      net.WriteString(ply_2:Nick())
+      net.Broadcast()
+      timer.Create("SoulmatesMinigameTimer", 0.1, 0, function()
+        if not ply_1:Alive() and ply_2:Alive() then
+          ply_2:Kill()
+        elseif not ply_2:Alive() and ply_1:Alive() then
+          ply_1:Kill()
+        end
+      end)
     end
 
-    timer.Create("SoulmatesMinigameTimer", 0.1, 0, function()
-      for i = 1, size do
-        if not ply1[i]:Alive() and ply2[i]:Alive() then
-          ply2[i]:Kill()
-        elseif ply1[i]:Alive() and not ply2[i]:Alive() then
-          ply1[i]:Kill()
-        end
-      end
-    end)
   end
 
   function MINIGAME:OnDeactivation()
     timer.Remove("SoulmatesMinigameTimer")
   end
+else
+  function MINIGAME:ShowActivationEPOP() end
+  net.Receive("ttt2mg_soulmate_epop", function()
+    local msg = net.ReadString()
+    if msg == "ttt2mg_soulmate_yours" then
+      local nick = net.ReadString()
+      msg = LANG.GetParamTranslation(msg, {nick = nick})
+    elseif msg == "ttt2mg_soulmate_none" then
+      msg = LANG.TryTranslation(msg)
+    elseif msg == "ttt2mg_soulmate_pair" then
+      msg = LANG.GetParamTranslation(msg, {nick1 = net.ReadString(), nick2 = net.ReadString()})
+    else return end
+
+    local client = LocalPlayer()
+    client:PrintMessage(HUD_PRINTTALK, msg)
+    EPOP:AddMessage({
+        text = msg,
+        color = COLOR_ORANGE
+    },
+      nil,
+      12,
+      nil,
+      true
+    )
+  end)
 end

--- a/lua/minigames/minigames/sh_suspicion_minigame.lua
+++ b/lua/minigames/minigames/sh_suspicion_minigame.lua
@@ -32,11 +32,11 @@ if SERVER then
   function MINIGAME:OnActivation()
     local plys = util.GetAlivePlayers()
     table.Shuffle(plys)
-    local suspicion_ply = plys[math.random(#plys)]
 
-    while not suspicion_ply:Alive() or suspicion_ply:IsSpec() or suspicion_ply:GetBaseRole() == ROLE_DETECTIVE do
-      suspicion_ply = plys[math]
-    end
+    local suspicion_ply = plys[math.random(#plys)]
+    -- while not suspicion_ply:Alive() or suspicion_ply:IsSpec() or suspicion_ply:GetBaseRole() == ROLE_DETECTIVE do
+    --   suspicion_ply = plys[math.random(#plys)]
+    -- end
 
     if not suspicion_ply:IsPlayer() then return end
 
@@ -53,45 +53,7 @@ if SERVER then
     end)
   end
 
-  function MINIGAME:OnDeactivation()
 
-  end
-end
-
-if CLIENT then
-  net.Receive("suspicion_minigame_popup", function()
-    local ply = net.ReadEntity()
-    local client = LocalPlayer()
-
-    if client:HasTeam(TEAM_TRAITOR) then
-      if ply:GetSubRole() == ROLE_TRAITOR then
-        EPOP:AddMessage({
-          text = ply:Nick() .. " is a traitor",
-          color = COLOR_RED
-          },
-          "",
-          4
-        )
-        client:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " is a traitor")
-      elseif ply:GetSubRole() == ROLE_JESTER then
-        EPOP:AddMessage(
-          {text = ply:Nick() .. " is a jester",
-          color = JESTER.ltcolor},
-          "",
-          4
-        )
-        client:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " is a jester")
-      end
-    else
-      EPOP:AddMessage(
-        {text = ply:Nick() .. " seems suspicious...",
-        color = COLOR_ORANGE},
-        "",
-        4
-      )
-      client:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " seems suspicious")
-    end
-  end)
   function MINIGAME:IsSelectable()
     if JESTER then
       return true
@@ -99,4 +61,47 @@ if CLIENT then
       return false
     end
   end
+end
+
+if CLIENT then
+  function MINIGAME:ShowActivationEPOP()
+
+  end
+  net.Receive("suspicion_minigame_popup", function()
+    local ply = net.ReadEntity()
+    local client = LocalPlayer()
+    local plynick = ply:Nick()
+    local sus_str = LANG.GetParamTranslation("ttt2mg_suspicion_epop_sus", {nick = plynick})
+    local jes_str = LANG.GetParamTranslation("ttt2mg_suspicion_epop_jes", {nick = plynick})
+    local tra_str = LANG.GetParamTranslation("ttt2mg_suspicion_epop_tra", {nick = plynick})
+
+    if client:HasTeam(TEAM_TRAITOR) then
+      if ply:GetSubRole() == ROLE_TRAITOR then
+        EPOP:AddMessage({
+          text = tra_str,
+          color = COLOR_RED
+          },
+          "",
+          6
+        )
+        client:PrintMessage(HUD_PRINTTALK, tra_str)
+      elseif ply:GetSubRole() == ROLE_JESTER then
+        EPOP:AddMessage(
+          {text = jes_str,
+          color = JESTER.ltcolor},
+          "",
+          6
+        )
+        client:PrintMessage(HUD_PRINTTALK, jes_str)
+      end
+    else
+      EPOP:AddMessage(
+        {text = sus_str,
+        color = COLOR_ORANGE},
+        "",
+        6
+      )
+      client:PrintMessage(HUD_PRINTTALK, sus_str)
+    end
+  end)
 end

--- a/lua/minigames/minigames/sh_suspicion_minigame.lua
+++ b/lua/minigames/minigames/sh_suspicion_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 0,
     max = 100,
-    desc = "(Def. 50)"
+    desc = "ttt2_minigames_suspicion_jst_chance (Def. 50)"
   }
 }
 

--- a/lua/minigames/minigames/sh_switch_minigame.lua
+++ b/lua/minigames/minigames/sh_switch_minigame.lua
@@ -10,7 +10,7 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 60,
-    desc = "(Def. 15)"
+    desc = "ttt2_minigames_switch_timer (Def. 15)"
   }
 }
 

--- a/lua/minigames/minigames/sh_switch_minigame.lua
+++ b/lua/minigames/minigames/sh_switch_minigame.lua
@@ -62,10 +62,12 @@ end
 if CLIENT then
   net.Receive("switch_minigame_popup", function()
     EPOP:AddMessage({
-      text = "Go!",
+      text = LANG.TryTranslation("ttt2mg_switch_epop"),
       color = COLOR_ORANGE},
-      "",
-      2
+      nil,
+      2,
+      nil,
+      true
     )
   end)
 end

--- a/lua/minigames/minigames/sh_texplode_minigame.lua
+++ b/lua/minigames/minigames/sh_texplode_minigame.lua
@@ -21,7 +21,6 @@ MINIGAME.conVarData = {
   }
 }
 
-local ttt2_minigames_texplode_timer = CreateConVar("ttt2_minigames_texplode_timer", "60", {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "How many credits should be available at a time?")
 
 if CLIENT then
   MINIGAME.lang = {
@@ -29,16 +28,25 @@ if CLIENT then
       English = "Explosive Traitors"
     },
     desc = {
-      English = "A traitor will explode in " .. ttt2_minigames_texplode_timer:GetInt() .. " seconds!"
+      English = "A traitor will explode in {time} seconds!"
     }
   }
 else
   util.AddNetworkString("texplode_popup")
+  util.AddNetworkString("ttt2mg_texplode_epop")
 end
 
 if SERVER then
+local ttt2_minigames_texplode_timer = CreateConVar("ttt2_minigames_texplode_timer", "60", {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "How many credits should be available at a time?")
 local ttt2_minigames_texplode_radius = CreateConVar("ttt2_minigames_texplode_radius", "600", {FCVAR_ARCHIVE}, "How many credits should be available at a time?")
+  function MINIGAME:ShowActivationEPOP()
+    net.Start("ttt2mg_texplode_epop")
+    net.WriteInt(ttt2_minigames_explode_timer:GetInt(), 32)
+    net.WriteString(self.name)
+    net.Broadcast()
+  end
   function MINIGAME:OnActivation()
+    self:ShowActivationEPOP()
     local x = 0
     local willExplode = true
 
@@ -64,15 +72,15 @@ local ttt2_minigames_texplode_radius = CreateConVar("ttt2_minigames_texplode_rad
       x = x + 1
       if delay >= 45 and x == delay - 30 then
         net.Start("texplode_popup")
-        net.WriteString("30 seconds until the traitor explodes!")
+        net.WriteString("ttt2mg_texplode_countdown_30")
         net.Broadcast()
       elseif delay >= 20 and x == delay - 10 then
         net.Start("texplode_popup")
-        net.WriteString("10 seconds remaining!")
+        net.WriteString("ttt2mg_texplode_countdown_10")
         net.Broadcast()
       elseif delay == x then
         net.Start("texplode_popup")
-        net.WriteString("The traitor has exploded!")
+        net.WriteString("ttt2mg_texplode_explode")
         net.Broadcast()
         tgt:EmitSound("ambient/explosions/explode_4.wav")
 
@@ -92,14 +100,28 @@ local ttt2_minigames_texplode_radius = CreateConVar("ttt2_minigames_texplode_rad
   end
 
 elseif CLIENT then
+  function MINIGAME:ShowActivationEPOP() end
+  net.Receive("ttt2mg_texplode_epop", function()
+    local mgtime = net.ReadInt(32)
+    local name = net.ReadString()
+    EPOP:AddMessage({
+        text = LANG.TryTranslation("ttt2_minigames_" .. name .. "_name"),
+        color = COLOR_ORANGE
+    },
+      LANG.GetParamTranslation("ttt2_minigames_" .. name .. "_desc", {time = mgtime}) or nil,
+      12,
+      nil,
+      true
+    )
+  end)
   net.Receive("texplode_popup", function()
     message = net.ReadString()
     if message then
       EPOP:AddMessage(
-        {text = message,
+        {text = LANG.TryTranslation(message),
         color = COLOR_ORANGE},
         "",
-        2
+        4
       )
     end
   end)

--- a/lua/minigames/minigames/sh_texplode_minigame.lua
+++ b/lua/minigames/minigames/sh_texplode_minigame.lua
@@ -10,14 +10,14 @@ MINIGAME.conVarData = {
     slider = true,
     min = 1,
     max = 120,
-    desc = "(Def. 60)"
+    desc = "ttt2_minigames_texplode_timer (Def. 60)"
   },
 
   ttt2_minigames_texplode_radius = {
     slider = true,
     min = 1,
     max = 1000,
-    desc = "(Def. 600)"
+    desc = "ttt2_minigames_texplode_radius (Def. 600)"
   }
 }
 

--- a/lua/terrortown/lang/english/minigames.lua
+++ b/lua/terrortown/lang/english/minigames.lua
@@ -1,0 +1,52 @@
+L = LANG.GetLanguageTableReference("english")
+
+--Communism
+L["ttt2mg_communism_epop"] = "{role} bought everyone {item}"
+
+--Explode
+L["ttt2mg_explode_epop"] = "{nick} exploded!"
+
+--Explosive Traitor
+L["ttt2mg_texplode_countdown_30"] = "30 seconds until the traitor explodes"
+L["ttt2mg_texplode_countdown_10"] = "10 seconds remaining!"
+L["ttt2mg_texplode_explode"] = "The traitor has exploded!"
+
+--Freeze
+-- L["ttt2mg_freeze_desc"] = "All Innocents will freeze (and become immune) every {time} seconds"
+L["ttt2mg_freeze_epop_1"] = "Winter is Coming"
+L["ttt2mg_freeze_epop_2"] = "The Ice Man Cometh"
+L["ttt2mg_freeze_epop_3"] = "In this universe, there is only one absolute: everything freezes!"
+L["ttt2mg_freeze_epop_4"] = "Tonight, Hell freezes over."
+L["ttt2mg_freeze_epop_5"] = "I'm afraid my condition has left me cold to your please of mercy."
+L["ttt2mg_freeze_epop_6"] = "Cool party."
+L["ttt2mg_freeze_epop_7"] = "You are not sending me to the cooler."
+L["ttt2mg_freeze_epop_8"] = "Stay cool, bird boy."
+L["ttt2mg_freeze_epop_9"] = "Alright, everyone! Chill!"
+L["ttt2mg_freeze_epop_10"] = "It's a cold town."
+L["ttt2mg_freeze_epop_11"] = "Tonight's forceast: a freeze is coming!"
+L["ttt2mg_freeze_epop_12"] = "What killed the dinosaurs? The Ice Age!"
+L["ttt2mg_freeze_epop_13"] = "Let's kick some ice!"
+L["ttt2mg_freeze_epop_14"] = "Can you feel it coming? The icy cold of space!"
+L["ttt2mg_freeze_epop_15"] = "Freeze in hell, Batman!"
+
+--Multigame
+L["ttt2mg_randomxn_epop"] = "Random x{count}"
+
+--Privacy
+L["ttt2mg_privacy_epop"] = "{role} bought {item}."
+
+--Soulmates
+L["ttt2mg_soulmate_yours"] = "Your soulmate is {nick}."
+L["ttt2mg_soulmate_none"] = "You have no soulmate. :("
+L["ttt2mg_soulmate_pair"] = "{nick1} and {nick2} are now soulmates."
+
+--Suspicion
+L["ttt2mg_suspicion_epop_sus"] = "{nick} seems suspicious..."
+L["ttt2mg_suspicion_epop_jes"] = "{nick} is a jester"
+L["ttt2mg_suspicion_epop_tra"] = "{nick} is a traitor"
+
+--Switch
+L["ttt2mg_switch_epop"] = "Go!"
+
+--You can only jump once
+L["ttt2mg_jump_epop"] = "{nick} tried to jump twice..."


### PR DESCRIPTION
- Moved Randomat, Intensify, and Random xN to use minigames.Select() function to choose minigame
- These games now use the MINIGAME:ShowActivationEPOP() function to override the default popup
- - Multigame (Displays the correct number based on ttt2_minigames_randomxn_count, "Random xN")
- - Speeeeeed! (Displays the correct additive percent based on ttt2_minigames_flash_scale)
- - Freeze! (New options to use a randomly picked pop culture quote to replace the title and another to hide description)
- - Soulmate (Skips the Soulmate name popup to show the Soulmate information, "X and Y are soulmates")
- - Suspicion (Skips the name popup to show who is minigame info, "X is suspicious...")
- Added English language file and replaced strings from the following games with Language table calls
- - Communism
- - Explode
- - Freeze
- - Multigame
- - Privacy
- - Soulmates
- - Suspicion
- - Switch
- - You can only jump once

And a handful of other bug fixes