### PR TITLE
Redesign Shut Up!-Minigame

### DIFF
--- a/lua/minigames/minigames/sh_shutup_minigame.lua
+++ b/lua/minigames/minigames/sh_shutup_minigame.lua
@@ -18,17 +18,14 @@ end
 
 if SERVER then
   function MINIGAME:OnActivation()
-    local plys = player.GetAll()
-    timer.Create("DeafMinigameDelay", 1, 1, function()
-      hook.Add("Think", "DeafMinigameThink", function()
-        for i = 1, #plys do
-          plys[i]:ConCommand("soundfade 100 1")
+    hook.Add("TTT2CanUseVoiceChat", "DeafMinigameAvoidVoice", function(ply, isTeam)
+        if IsValid(ply) then
+            return false
         end
-      end)
     end)
   end
 
   function MINIGAME:OnDeactivation()
-    hook.Remove("Think", "DeafMinigameThink")
+    hook.Remove("TTT2CanUseVoiceChat", "DeafMinigameAvoidVoice")
   end
 end


### PR DESCRIPTION
I've changed the minigame's logic to a TTT2-Hook that's more performant than a Think hook combined with a ConCommand. It's not tested yet, but should work as I used this hook like this in another script as well. I didn't know that this hook exists until Tim released the hook TTT2 API docu two weeks ago. 

You could also run this hook on the client, too. This would result in the voice chat UI element not being drawn on the client side in the first place. But I haven't done that for now. As long as the hook only runs on the server, at least the voice chat is killed.

More details about the hook, you can find here: https://api-docs.ttt2.neoxult.de/hook/GM/shared/GM:TTT2CanUseVoiceChat